### PR TITLE
Add Initial Club Structural Outlines

### DIFF
--- a/Awards/README.md
+++ b/Awards/README.md
@@ -1,0 +1,10 @@
+# Awards
+## Project Completion Awards
+## Community Service Awards
+## Project Maintenance Awards
+## Technical Achievement Awards
+## Leadership Awards
+## Club Uplift Awards
+## Club Growth Awards
+## Committee Granted Awards
+## Council Granted Awards

--- a/Governance/README.md
+++ b/Governance/README.md
@@ -1,0 +1,14 @@
+# Governance
+## Club Master
+### Quartermaster
+### Projects Manager
+## Tech Lead Council
+### Senior Tech Lead
+### Tech Leads
+## Resource Committee
+### Awards Chair
+### Rank Advancement Chair
+### Treasurer
+### Inventory Chair
+### Community Outreach Chair
+### Growth Chair

--- a/Meetings/README.md
+++ b/Meetings/README.md
@@ -1,0 +1,7 @@
+# Club Meetings
+### "Regular" Meetings
+### Project Meetings
+
+### Tech Lead Council Meetings
+
+### Resource Committee Meetings

--- a/Memberships/README.md
+++ b/Memberships/README.md
@@ -1,0 +1,7 @@
+# Memberships
+## Members
+### Membership Dues
+### Membership Perks
+## Growth
+### New Member Requirements
+### New Member On-Boarding Pipeline

--- a/Projects/README.md
+++ b/Projects/README.md
@@ -1,0 +1,6 @@
+# Club Projects
+
+## Types of Projects
+This chapter of the club aims to limit the scope of the projects it takes on to increase its efficacy.  The following project categories are considered under the chapter's domain.
+### Technical Projects
+### Outreach Projects

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Introduction
+Welcome to the first chapter of The Foundation Software Club (name?)
+
+---
+## Meetings
+The Club meets regularly on **Tuesdays** for **2 Hours**.  See [Meetings](./Meetings/README)
+
+---
+## Projects
+The Club maintains and executes a backlog of projects to serve the club and the community.  See [Projects](./Projects/README)
+
+---
+## Memberships
+Folk interested in advancing their craft would seek to become members, and the club would seek to expand its member base. See [Memberships](./Memberships/README)
+
+---
+## Teams
+Projects and activities will be carried out by teams of volunteer members.  See [Teams](./Teams/README)
+
+---
+## Awards
+Teams and members will be given awards at award ceremonies to celebrate the achievements of the Club.  See [Awards](./Awards/README)
+
+---
+## Ranks
+Members can advance their technical status within the club by working to advance their rank along a fixed ranking path.  See [Ranks](./Ranks/README)
+
+---
+## Governance Structures
+The clubs activities will be overseen by self correcting governance structures to keep the organization stable and growing.  See [Governance](./Governance/README)

--- a/Ranks/README.md
+++ b/Ranks/README.md
@@ -1,0 +1,8 @@
+# Ranks
+## Junior Apprentice
+## Apprentice
+## Journeyperson
+## Craftsperson
+## Artisan
+## Senior Artisan
+## Master

--- a/Teams/README.md
+++ b/Teams/README.md
@@ -1,0 +1,7 @@
+# Teams
+## Team Roles
+### Tech Leads
+### Resident Specialists
+## Team Types
+### Project Teams
+### Service Teams


### PR DESCRIPTION
Add outlines for the components for the initial club structure, capturing the following categories:

- Meetings
- Projects
- Memberships
- Teams
- Awards
- Ranks
- Governance